### PR TITLE
Added monitor span support

### DIFF
--- a/src/Main.vala
+++ b/src/Main.vala
@@ -22,8 +22,8 @@ namespace Wallpaper {
 
     public static void main (string [] args) {
 
-        if(args[1] == "--help" || args[1] == "-h") {
-            print("Usage:\n\tanimated-wallpaper [FILE]");
+        if(args[1] == "--help" || args[1] == "-h" || args.length == 1) {
+            print("Usage:\n\tanimated-wallpaper [FILE] [FLAG]");
             print("\n\t--span || -s To stretch video across all monitors\n");
             return;
         }

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -22,9 +22,15 @@ namespace Wallpaper {
 
     public static void main (string [] args) {
 
-        if(args[1] == "--help" || args[1] == "-h" || args.length != 2) {
+        if(args[1] == "--help" || args[1] == "-h") {
             print("Usage:\n\tanimated-wallpaper [FILE]");
+            print("\n\t--span || -s To stretch video across all monitors\n");
             return;
+        }
+
+        bool spanMonitors = false;
+        for(int i = 0; i < args.length; i++) {
+            if(args[i] == "--span" || args[i] == "-s") spanMonitors = true;
         }
 
         GtkClutter.init (ref args);
@@ -37,7 +43,10 @@ namespace Wallpaper {
         backgroundWindows = new BackgroundWindow[monitorCount];
         string fileName = args[1];
         for (int i = 0; i < monitorCount; ++i)
-            backgroundWindows[i] = new BackgroundWindow(i, fileName);
+            backgroundWindows[i] = new BackgroundWindow(i,
+                                                        fileName,
+                                                        monitorCount,
+                                                        spanMonitors);
 
         var mainSettings = Gtk.Settings.get_default ();
         mainSettings.set("gtk-xft-antialias", 1, null);

--- a/src/Playable.vala
+++ b/src/Playable.vala
@@ -33,12 +33,15 @@ namespace Playable {
 
 		Clutter.Actor wallpaperActor = new Clutter.Actor();
 
-		public BackgroundWindow (int monitorIndex, string fileName) {
+		public BackgroundWindow (int monitorIndex,
+                                 string fileName,
+                                 int monitorCount,
+                                 bool spanMonitors) {
 
 			title = "Desktop";
 
 			// Get current monitor size
-			getMonitorSize(monitorIndex);
+			getMonitorSize(monitorIndex, monitorCount, spanMonitors);
 
             embed = new GtkClutter.Embed() {width_request = screenWidth, height_request = screenHeight};
             mainActor = embed.get_stage();
@@ -71,7 +74,7 @@ namespace Playable {
 			add(embed);
 		}
 
-		void getMonitorSize(int monitorIndex) {
+		void getMonitorSize(int monitorIndex, int monitorCount, bool spanMonitors) {
 
 			Rectangle rectangle;
 			var screen = Gdk.Screen.get_default ();
@@ -79,7 +82,8 @@ namespace Playable {
 			screen.get_monitor_geometry (monitorIndex, out rectangle);
 
 			screenHeight = rectangle.height;
-			screenWidth = rectangle.width;
+			if(spanMonitors) screenWidth = rectangle.width*monitorCount;
+			else screenWidth = rectangle.width;
 
 			move(rectangle.x, rectangle.y);
 
@@ -104,7 +108,7 @@ namespace Playable {
             });
 
             wallpaperActor.scale_y = 1.00f;
-            wallpaperActor.scale_x = 1.00f;   
+            wallpaperActor.scale_x = 1.00f;
 
             videoPlayback.set_filename(fileName);
             videoPlayback.playing = true;
@@ -115,8 +119,8 @@ namespace Playable {
 
         // void setImageWallpaper(string fileName) {
         //     wallpaperActor.scale_y = 1.05f;
-        //     wallpaperActor.scale_x = 1.05f;   
-        //     
+        //     wallpaperActor.scale_x = 1.05f;
+        //
         //     Gtk.Image image = new Gtk.Image.from_file(fileName);
         //     GtkClutter.Actor actor = new GtkClutter.Actor.with_contents(image);
         //     actor.set_size(screenWidth, screenHeight);


### PR DESCRIPTION
Hey there!

I've added the ability to have the video stretch across dual monitors (an probably more, but I can't test it).
This is for when you make a video that is the combined width of both monitors. Previously it would squish the width and display a copy on each monitor.
This can be done by adding an optional `--span` or `-s` after the file name.
I've also made it throw an error if no arguments are given. This doesn't stop you from adding more than the file name and `-s`, but it'll simply ignore everything after.

I tried to keep your formatting style while editing. Let me know what you think. This is kinda my first pull request :D

Have a glorious day!